### PR TITLE
Fix missing faded styling for previous steps

### DIFF
--- a/src/app_modules_assistor/style.css
+++ b/src/app_modules_assistor/style.css
@@ -39,6 +39,10 @@ body {
     background-color: hsl(189, 100%, 97.04%); /* Very Light Pastel Cyan */
 }
 
+.faded {
+    opacity: 0.5;
+}
+
 .question {
     font-size: 16px;
     font-weight: 500;


### PR DESCRIPTION
## Summary
- add `.faded` style so answered questions fade out

## Testing
- `python build.py`

------
https://chatgpt.com/codex/tasks/task_e_68453bfc34a08322959e006623be5b59