### PR TITLE
Add upload endpoint tests

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,16 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import types
+requests_stub = types.ModuleType("requests")
+sys.modules.setdefault("requests", requests_stub)
+from upload import construct_upload_endpoint, UPLOAD_ENDPOINT_TEMPLATE_NO_ACTION_NAME
+
+
+def test_construct_upload_endpoint_with_action():
+    url = construct_upload_endpoint('my_action')
+    assert url.endswith('/my_action/bundle')
+
+
+def test_construct_upload_endpoint_no_action():
+    url = construct_upload_endpoint(None)
+    assert url == UPLOAD_ENDPOINT_TEMPLATE_NO_ACTION_NAME


### PR DESCRIPTION
## Summary
- add pytest unit tests covering `construct_upload_endpoint`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684540d450d88322985daa40b0bb04af